### PR TITLE
Update tierprinter and starting money

### DIFF
--- a/lua/darkrp_config/settings.lua
+++ b/lua/darkrp_config/settings.lua
@@ -267,7 +267,7 @@ GM.Config.shipmentspawntime             = 10
 -- startinghealth - the health when you spawn.
 GM.Config.startinghealth                = 100
 -- startingmoney - your wallet when you join for the first time.
-GM.Config.startingmoney                 = 5000
+GM.Config.startingmoney                 = 500
 -- vehiclecost - Sets the cost of a vehicle (To own it).
 GM.Config.vehiclecost                   = 40
 -- wallettaxmax - Maximum percentage of tax to be paid.

--- a/lua/darkrp_customthings/entities.lua
+++ b/lua/darkrp_customthings/entities.lua
@@ -75,14 +75,6 @@ DarkRP.createEntity("Suppressors", {
 	category = "Attachments",
 })
 
-DarkRP.createEntity("Printer", { 
-    ent = "tierp_printer", 
-    model = "models/freeman/money_printer.mdl", 
-    price = 3000, 
-    max = 2, 
-    cmd = "buytierprinter" 
-}) 
-
 DarkRP.createEntity("9x19mm Ammo", {
 	ent = "cw_ammo_9x19",
 	model = "models/Items/BoxMRounds.mdl",


### PR DESCRIPTION
Removes tierprinter from the entities menu and sets starting money back to the vanilla $500