### PR TITLE
Update removeclassitems

### DIFF
--- a/lua/darkrp_config/settings.lua
+++ b/lua/darkrp_config/settings.lua
@@ -132,7 +132,7 @@ GM.Config.proppaying                    = false
 -- propspawning - Enable/disable props spawning. Applies to admins too.
 GM.Config.propspawning                  = true
 -- removeclassitems - Enable/disable shipments/microwaves/etc. removal when someone changes team.
-GM.Config.removeclassitems              = true
+GM.Config.removeclassitems              = false
 -- removeondisconnect - Enable/disable shipments/microwaves/etc. removal when someone disconnects.
 GM.Config.removeondisconnect            = false
 -- respawninjail - Enable/disable whether people can respawn in jail when they die.


### PR DESCRIPTION
Set removeclassitems to false, so objects like food and shipments aren't removed when someone switches jobs.